### PR TITLE
Fixed bug for when cdk-synth is skipped

### DIFF
--- a/.github/workflows/main-pipeline-cdk.yml
+++ b/.github/workflows/main-pipeline-cdk.yml
@@ -67,7 +67,7 @@ jobs:
 
   cdk-deploy:
     ## If the PR is merged, or if we manually trigger it (MAIN ONLY):
-    if: ( github.event_name == 'pull_request' && github.event.pull_request.merged ) ||
+    if: ( github.event_name == 'pull_request' && github.event.pull_request.merged && needs.cdk-synth.result == 'skipped') ||
         ( github.event_name == 'workflow_dispatch' )
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Let the cdk-deploy run when PR's are merged