### PR TITLE
Added metric to detect when task goes haywire, and shut down system

### DIFF
--- a/ContainerManager/leaf_stack/NestedStacks/Dashboard.py
+++ b/ContainerManager/leaf_stack/NestedStacks/Dashboard.py
@@ -113,6 +113,7 @@ class Dashboard(NestedStack):
                 alarms=[
                     watchdog_nested_stack.alarm_asg_instance_left_up,
                     watchdog_nested_stack.alarm_container_activity,
+                    watchdog_nested_stack.alarm_capacity_provider,
                 ],
             ),
 
@@ -154,6 +155,15 @@ class Dashboard(NestedStack):
                 width=6,
                 height=5,
                 alarm=watchdog_nested_stack.alarm_container_activity,
+            ),
+
+            ## Capacity Provider Alarm:
+            # https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.AlarmWidget.html
+            cloudwatch.AlarmWidget(
+                title=f"Alarm: {watchdog_nested_stack.alarm_capacity_provider.alarm_name}",
+                width=6,
+                height=5,
+                alarm=watchdog_nested_stack.alarm_capacity_provider,
             ),
 
             ## Show the Container Logs:

--- a/ContainerManager/leaf_stack/NestedStacks/EcsAsg.py
+++ b/ContainerManager/leaf_stack/NestedStacks/EcsAsg.py
@@ -193,6 +193,10 @@ class EcsAsg(NestedStack):
             ## Since the instances don't live long, this doesn't do anything, and
             # the lambda to spin down the system will trigger TWICE when going down.
             enable_managed_draining=False,
+            ## We need the `CapacityProviderReservation` metric to know when to kill the ec2 instance
+            # if the container exists on startup. (Otherwise the task infinite loops, and since it
+            # successfully started FIRST, the circuit breaker won't stop it).
+            enable_managed_scaling=True,
         )
 
         self.ecs_cluster.add_asg_capacity_provider(self.capacity_provider)

--- a/ContainerManager/leaf_stack/NestedStacks/README.md
+++ b/ContainerManager/leaf_stack/NestedStacks/README.md
@@ -2,47 +2,6 @@
 
 I broke out the core architecture into [Nested Stacks](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.NestedStack.html), to keep each "chunk" easy to understand and manage. It was becoming a tangled mess of dependencies, and you'd have no idea what would create a circular import otherwise. All of this is still apart of a single "Stack" (The [Main Stack](../README.md#main-stack---mainpy).)
 
-## Dependency Graph
-
-```mermaid
-flowchart LR
-    %% ID's
-    SecurityGroups[SecurityGroups.py]
-    Container[Container.py]
-    Volumes[Volumes.py]
-    EcsAsg[EcsAsg.py]
-    Watchdog[Watchdog.py]
-    AsgStateChangeHook[AsgStateChangeHook.py]
-
-    %% SecurityGroups - Nothing
-    %% Container - Nothing
-
-    %% Volumes
-    SecurityGroups --sg_efs_traffic--> Volumes
-    Container -- task_definition
-                 container
-              --> Volumes
-
-    %% EcsAsg
-    Container --task_definition--> EcsAsg
-    SecurityGroups --sg_container_traffic--> EcsAsg
-    Volumes --  efs_file_system
-            host_access_point
-        --> EcsAsg
-
-    %% Watchdog
-    EcsAsg -- auto_scaling_group
-              scale_down_asg_action
-           --> Watchdog
-
-    %% AsgStateChangeHook
-    EcsAsg -- ecs_cluster
-              ec2_service
-              auto_scaling_group
-           --> AsgStateChangeHook
-    Watchdog --rule_watchdog_trigger--> AsgStateChangeHook
-```
-
 ## Components
 
 ### SecurityGroups

--- a/ContainerManager/leaf_stack/main.py
+++ b/ContainerManager/leaf_stack/main.py
@@ -130,6 +130,8 @@ class ContainerManagerStack(Stack):
             watchdog_config=config["Watchdog"],
             auto_scaling_group=self.ecs_asg_nested_stack.auto_scaling_group,
             base_stack_sns_topic=base_stack.sns_notify_topic,
+            ecs_cluster=self.ecs_asg_nested_stack.ecs_cluster,
+            ecs_capacity_provider=self.ecs_asg_nested_stack.capacity_provider,
         )
 
         ### All the info for the Asg StateChange Hook Stuff
@@ -146,19 +148,20 @@ class ContainerManagerStack(Stack):
         #######################
         ### Dashboard Stuff ###
         #######################
-        self.dashboard_nested_stack = NestedStacks.Dashboard(
-            self,
-            description=f"Dashboard Logic for {construct_id}",
-            application_id=application_id,
-            container_id=container_id,
-            main_config=config,
+        if config["Dashboard"]["Enabled"]:
+            self.dashboard_nested_stack = NestedStacks.Dashboard(
+                self,
+                description=f"Dashboard Logic for {construct_id}",
+                application_id=application_id,
+                container_id=container_id,
+                main_config=config,
 
-            domain_stack=domain_stack,
-            container_nested_stack=self.container_nested_stack,
-            ecs_asg_nested_stack=self.ecs_asg_nested_stack,
-            watchdog_nested_stack=self.watchdog_nested_stack,
-            asg_state_change_hook_nested_stack=self.asg_state_change_hook_nested_stack,
-        )
+                domain_stack=domain_stack,
+                container_nested_stack=self.container_nested_stack,
+                ecs_asg_nested_stack=self.ecs_asg_nested_stack,
+                watchdog_nested_stack=self.watchdog_nested_stack,
+                asg_state_change_hook_nested_stack=self.asg_state_change_hook_nested_stack,
+            )
 
         #####################
         ### cdk_nag stuff ###

--- a/ContainerManager/utils/config_loader.py
+++ b/ContainerManager/utils/config_loader.py
@@ -228,6 +228,10 @@ def _parse_dashboard(config: dict) -> None:
     if "Dashboard" not in config:
         config["Dashboard"] = {}
     assert isinstance(config["Dashboard"], dict)
+    ### If Enabled
+    if "Enabled" not in config["Dashboard"]:
+        config["Dashboard"]["Enabled"] = True
+    assert isinstance(config["Dashboard"]["Enabled"], bool)
     ### IntervalMinutes
     if "IntervalMinutes" not in config["Dashboard"]:
         config["Dashboard"]["IntervalMinutes"] = 30


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the task can start, but then something in their entrypoint throws, ecs will just restart it. (And because you technically started, it won't trip the circuit breaker). This logic will (hopefully) see the task spinning up and down constantly, and spin the ec2 instance to avoid paying for something you're not using.
