### PR TITLE
Switched out Instance Count with looking at Netork Metric, to reduce cloudwatch API calls

### DIFF
--- a/ContainerManager/leaf_stack/NestedStacks/EcsAsg.py
+++ b/ContainerManager/leaf_stack/NestedStacks/EcsAsg.py
@@ -172,12 +172,6 @@ class EcsAsg(NestedStack):
                 # Let users of this specific stack know the same thing:
                 autoscaling.NotificationConfiguration(topic=leaf_stack_sns_topic, scaling_events=autoscaling.ScalingEvents.ERRORS),
             ],
-            # Make it push number of instances to cloudwatch, so you can warn user if it's up too long:
-            group_metrics=[
-                autoscaling.GroupMetrics(
-                    autoscaling.GroupMetric.IN_SERVICE_INSTANCES,
-                ),
-            ],
         )
 
         ## This allows an ECS cluster to target a specific EC2 Auto Scaling Group for the placement of tasks.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Before, even if the system was off, the metric would constantly be hitting cloudwatch api (always showing 0 every minute). Changed logic to use asg networking, and if there's no data, assume the instance is off.

Also Dashboard Improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
  - [ ] I have added tests to cover my changes.
